### PR TITLE
Follow cartographer fix for raytracing

### DIFF
--- a/cartographer_ros/cartographer_ros/assets_writer.cc
+++ b/cartographer_ros/cartographer_ros/assets_writer.cc
@@ -122,8 +122,8 @@ std::unique_ptr<carto::io::PointsBatch> HandleMessage(
     const carto::transform::Rigid3f sensor_to_map =
         (tracking_to_map * sensor_to_tracking).cast<float>();
     points_batch->points.push_back(
-        sensor_to_map *
-        carto::sensor::ToRangefinderPoint(point_cloud.points[i]));
+        sensor_to_map * carto::sensor::ToRangefinderPoint(
+                            point_cloud.points[i], Eigen::Vector3f::Zero()));
     points_batch->intensities.push_back(point_cloud.intensities[i]);
     // We use the last transform for the origin, which is approximately correct.
     points_batch->origin = sensor_to_map * Eigen::Vector3f::Zero();


### PR DESCRIPTION
Now the RangePoint on cartographer is composed not only by a position of
the point but also from the origin of the ray, and here we update to
support this new interface.

Port of https://github.com/cartographer-project/cartographer_ros/pull/1682 to ironox fork.